### PR TITLE
Update package download URLs to their correct values.

### DIFF
--- a/buildroot/package/dosfstools/dosfstools.mk
+++ b/buildroot/package/dosfstools/dosfstools.mk
@@ -5,7 +5,7 @@
 #############################################################
 
 DOSFSTOOLS_VERSION = 3.0.16
-DOSFSTOOLS_SITE = http://fossies.org/linux/misc
+DOSFSTOOLS_SITE = http://daniel-baumann.ch/files/software/dosfstools
 DOSFSTOOLS_LICENSE = GPLv3+
 DOSFSTOOLS_LICENSE_FILES = COPYING
 DOSFSTOOLS_LDFLAGS = $(TARGET_LDFLAGS)

--- a/buildroot/package/jsmin/jsmin.mk
+++ b/buildroot/package/jsmin/jsmin.mk
@@ -1,5 +1,5 @@
 JSMIN_VERSION = a9b4755
-JSMIN_SITE = http://github.com/douglascrockford/JSMin/tarball/master
+JSMIN_SITE = http://github.com/douglascrockford/JSMin/tarball/$(JSMIN_VERSION)
 
 define JSMIN_BUILD_CMDS
 	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D) jsmin

--- a/buildroot/package/libcofi/libcofi.mk
+++ b/buildroot/package/libcofi/libcofi.mk
@@ -5,7 +5,7 @@
 #############################################################
 
 LIBCOFI_VERSION = 7313fbe12b0593034d0a1b606bf33c7cf4ababce
-LIBCOFI_SITE = http://github.com/simonjhall/copies-and-fills/tarball/master
+LIBCOFI_SITE = http://github.com/simonjhall/copies-and-fills/tarball/$(LIBCOFI_VERSION)
 LIBCOFI_LICENSE = LGPLv2.1
 LIBCOFI_LICENSE_FILES = README.md
 

--- a/buildroot/package/linenoise/linenoise.mk
+++ b/buildroot/package/linenoise/linenoise.mk
@@ -3,8 +3,8 @@
 # linenoise
 #
 #############################################################
-LINENOISE_VERSION = g27a3b4d
-LINENOISE_SITE = http://github.com/antirez/linenoise/tarball/master
+LINENOISE_VERSION = 27a3b4d5
+LINENOISE_SITE = http://github.com/antirez/linenoise/tarball/$(LINENOISE_VERSION)
 LINENOISE_LICENSE = BSD-2c
 LINENOISE_INSTALL_STAGING = YES
 

--- a/buildroot/package/lua-msgpack-native/lua-msgpack-native.mk
+++ b/buildroot/package/lua-msgpack-native/lua-msgpack-native.mk
@@ -3,8 +3,8 @@
 # lua-msgpack-native
 #
 #############################################################
-LUA_MSGPACK_NATIVE_VERSION = g41cce91
-LUA_MSGPACK_NATIVE_SITE = http://github.com/kengonakajima/lua-msgpack-native/tarball/master
+LUA_MSGPACK_NATIVE_VERSION = 41cce91
+LUA_MSGPACK_NATIVE_SITE = http://github.com/kengonakajima/lua-msgpack-native/tarball/$(LUA_MSGPACK_NATIVE_VERSION)
 LUA_MSGPACK_NATIVE_DEPENDENCIES = lua
 LUA_MSGPACK_NATIVE_LICENSE = Apache-2.0
 LUA_MSGPACK_NATIVE_LICENSE_FILES = LICENSE.txt

--- a/buildroot/package/mtdev2tuio/mtdev2tuio.mk
+++ b/buildroot/package/mtdev2tuio/mtdev2tuio.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 MTDEV2TUIO_VERSION = e1e7378
-MTDEV2TUIO_SITE = http://github.com/olivopaolo/mtdev2tuio/tarball/master
+MTDEV2TUIO_SITE = http://github.com/olivopaolo/mtdev2tuio/tarball/$(MTDEV2TUIO_VERSION)
 MTDEV2TUIO_DEPENDENCIES = mtdev liblo
 MTDEV2TUIO_LICENSE = GPLv3+
 MTDEV2TUIO_LICENSE_FILES = COPYING

--- a/buildroot/package/ne10/ne10.mk
+++ b/buildroot/package/ne10/ne10.mk
@@ -7,7 +7,7 @@
 # We use a Git commit ID because the last tagged version is more than
 # one year old.
 NE10_VERSION = 88c18f0
-NE10_SITE = http://github.com/projectNe10/Ne10/tarball/master
+NE10_SITE = http://github.com/projectNe10/Ne10/tarball/$(NE10_VERSION)
 NE10_LICENSE = BSD-3c or Apache 2.0
 NE10_LICENSE_FILES = doc/LICENSE
 

--- a/buildroot/package/omap-u-boot-utils/omap-u-boot-utils.mk
+++ b/buildroot/package/omap-u-boot-utils/omap-u-boot-utils.mk
@@ -5,7 +5,7 @@
 #############################################################
 
 OMAP_U_BOOT_UTILS_VERSION = 8aff852
-OMAP_U_BOOT_UTILS_SITE = http://github.com/nmenon/omap-u-boot-utils/tarball/master
+OMAP_U_BOOT_UTILS_SITE = http://github.com/nmenon/omap-u-boot-utils/tarball/$(OMAP_U_BOOT_UTILS_VERSION)
 
 define HOST_OMAP_U_BOOT_UTILS_BUILD_CMDS
 	$(MAKE) -C $(@D)

--- a/buildroot/package/rpi-firmware/rpi-firmware.mk
+++ b/buildroot/package/rpi-firmware/rpi-firmware.mk
@@ -6,7 +6,7 @@
 
 #RPI_FIRMWARE_VERSION = 76d0ac38f16b6343c6155c80db1e4758b3a5838a
 RPI_FIRMWARE_VERSION = master
-RPI_FIRMWARE_SITE = http://github.com/raspberrypi/firmware/tarball/master
+RPI_FIRMWARE_SITE = http://github.com/raspberrypi/firmware/tarball/$(RPI_FIRMWARE_VERSION)
 RPI_FIRMWARE_LICENSE = BSD-3c
 RPI_FIRMWARE_LICENSE_FILE = boot/LICENCE.broadcom
 

--- a/buildroot/package/rpi-userland/rpi-userland.mk
+++ b/buildroot/package/rpi-userland/rpi-userland.mk
@@ -5,7 +5,7 @@
 #############################################################
 
 RPI_USERLAND_VERSION = 5e9a740a88a889dfc8a18bb1b00c17e5dd9d0108
-RPI_USERLAND_SITE = http://github.com/raspberrypi/userland/tarball/master
+RPI_USERLAND_SITE = http://github.com/raspberrypi/userland/tarball/$(RPI_USERLAND_VERSION)
 RPI_USERLAND_LICENSE = BSD-3c
 RPI_USERLAND_LICENSE_FILE = LICENCE
 RPI_USERLAND_INSTALL_STAGING = YES

--- a/buildroot/package/socketcand/socketcand.mk
+++ b/buildroot/package/socketcand/socketcand.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 SOCKETCAND_VERSION = 7d06986
-SOCKETCAND_SITE = http://github.com/dschanoeh/socketcand/tarball/master
+SOCKETCAND_SITE = http://github.com/dschanoeh/socketcand/tarball/$(SOCKETCAND_VERSION)
 SOCKETCAND_AUTORECONF = YES
 SOCKETCAND_DEPENDENCIES = libconfig
 

--- a/buildroot/package/ti-utils/ti-utils.mk
+++ b/buildroot/package/ti-utils/ti-utils.mk
@@ -5,7 +5,7 @@
 #############################################################
 
 TI_UTILS_VERSION = 06dbdb2
-TI_UTILS_SITE = http://github.com/gxk/ti-utils/tarball/master
+TI_UTILS_SITE = http://github.com/gxk/ti-utils/tarball/$(TI_UTILS_VERSION)
 TI_UTILS_DEPENDENCIES = libnl
 
 define TI_UTILS_BUILD_CMDS

--- a/buildroot/package/tslib/tslib.mk
+++ b/buildroot/package/tslib/tslib.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 TSLIB_VERSION = 158ee49b32f83cb7b02d5315f41c2e4cff38942d
-TSLIB_SITE = http://github.com/kergoth/tslib/tarball/master
+TSLIB_SITE = http://github.com/kergoth/tslib/tarball/$(TSLIB_VERSION)
 TSLIB_LICENSE = GPL, LGPL
 TSLIB_LICENSE_FILES = COPYING
 


### PR DESCRIPTION
This cherry-picks the upstream buildroot fixes required for
https://bugs.busybox.net/show_bug.cgi?id=6302
https://bugs.busybox.net/show_bug.cgi?id=6308
and is basically a re-application (forgive my incorrect terminology)
of the following upstream buildroot git commit ids, focusing
purely on the _SITE settings and leaving the _VERSION settings as-is:
f0f124f36a8616a1e0895b2eb9411a8459daa3c9  (jsmin)
9bb2757c461271f4458294d417f440f839513e33  (libcofi)
b89e8141e3247e28387e14a2959d3ec8ea11f12c  (linenoise)
55c90b10b3c73ff0708ceb73645c51658f4821aa  (lua-msgpack-native)
e9c9bd2d62a1d09f2f54b55f05301be0e06981df  (mtdev2tuio)
c2b205c038bc0dba3960917f2eb1bd30fbc24b03  (ne10)
ae5be552b6435437db42b168b61aa15b8bed2fbc  (omap-u-boot-utils)
6b16001d4f026fd08f14a4b2043710531b50a0ad  (rpi-firmware)
8645437c0cc0fffa6962030ddd90698ab917891e  (rpi-userland)
fe64434df6c8a5f3516f92caf9c04d6dedda444b  (socketcand)
7869f83bda815279f8245913d33062e525d4efe1  (ti-utils)
013365238f0b00f01dcc173edf2f3b6e37f7beb1  (tslib)
41190ef0f1ffb68675bfe77205e9207363546377  (linenoise)
0b8ed5b53d066f86f09e01d02a5e0bd715c17b70  (lua-msgpack-native)
06938c3a9e3b3d41606e5d08256671d0d48fbfa8  (dosfstools)
