### PR TITLE
Make language label right-aligned

### DIFF
--- a/recovery/languagedialog.ui
+++ b/recovery/languagedialog.ui
@@ -105,6 +105,9 @@
      <property name="text">
       <string>Language (L):  </string>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
     </widget>
    </item>
    <item row="0" column="1">


### PR DESCRIPTION
Some of the translations for the "Language : " string are so much shorter than others, that I think they look better if they're right-aligned, rather than defaulting to left-aligned.
But this is obviously a matter of taste, so I won't be upset if you close this pull-request rather than merging it ;-)
