### PR TITLE
Boolean selection of alternative image source repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Even if you are using your Pi without a display, you can still use NOOBS to easi
 
 When you now boot your Pi using an SD card containing the modified version of NOOBS that you just created, it will automatically install the OS you chose and boot into it after the installation has finished.
 
+### How to install OSes from an alternative source
+
+An alternative source of OSes to be downloaded from the internet can be specified by adding <b>alt_image_source=http://newurl.com/os_list.json</b> to the argument list in recovery.cmdline, where `newurl.com` is the name of the alternative server and `os_list.json` is the list of information about the alternative OSes. This list of OSes will be added to the default download list. This can be useful for storing the default repository on a local LAN server, or for adding your own list of OSes to those available in NOOBS.
+
+To suppress the default URL and only use the alternative image source for downloading OS images, add <b>no_default_source</b>. Using this option without `alt_image_source` will prevent all internet downloads and just allow local OSes on the SD card to be listed.
+
 ### How to create a custom OS version
 
 There are two main use cases for which you may want to create a custom version of one of the standard OS releases that is suitable for installation via NOOBS:

--- a/buildroot/package/recovery/init
+++ b/buildroot/package/recovery/init
@@ -41,6 +41,8 @@ else
     DEFAULT_KBD=
     DEFAULT_DISPLAY=
     DEFAULT_PARTITION=
+    DEFAULT_REPOS=
+    EXTRA_REPOS=
 
     if grep -q runinstaller /proc/cmdline; then
         RUN_INSTALLER=-runinstaller
@@ -53,6 +55,9 @@ else
     fi
     if grep -q forcetrigger /proc/cmdline; then
         FORCE_TRIGGER=-forcetrigger
+    fi
+    if grep -q no_default_source /proc/cmdline; then
+        DEFAULT_REPOS=-no_default_source
     fi
     for p in `cat /proc/cmdline` ; do
         if [ "${p%%=*}" == "lang" ] ; then
@@ -67,9 +72,12 @@ else
         if [ "${p%%=*}" == "partition" ] ; then
             DEFAULT_PARTITION="-partition ${p#*=}"
         fi
+        if [ "${p%%=*}" == "alt_image_source" ] ; then
+            EXTRA_REPOS="-alt_image_source ${p#*=}"
+        fi
     done
 
-    /usr/bin/recovery $RUN_INSTALLER $GPIO_TRIGGER $KEYBOARD_NO_TRIGGER $FORCE_TRIGGER $DEFAULT_KBD $DEFAULT_LANG $DEFAULT_DISPLAY $DEFAULT_PARTITION -qws 2>/tmp/debug
+    /usr/bin/recovery $RUN_INSTALLER $GPIO_TRIGGER $KEYBOARD_NO_TRIGGER $FORCE_TRIGGER $DEFAULT_KBD $DEFAULT_LANG $DEFAULT_DISPLAY $DEFAULT_PARTITION $DEFAULT_REPOS $EXTRA_REPOS -qws 2>/tmp/debug
 
 fi
 

--- a/recovery/main.cpp
+++ b/recovery/main.cpp
@@ -34,6 +34,9 @@
  *
  */
 
+QString defaultRepos (DEFAULT_REPO_SERVER);
+QString extraRepos;
+
 void reboot_to_extended(const QString &defaultPartition, bool setDisplayMode)
 {
     // Unmount any open file systems
@@ -73,7 +76,6 @@ int main(int argc, char *argv[])
         gpioChannel = 0;
     else
         gpioChannel = 2;
-
     QApplication a(argc, argv);
     RightButtonFilter rbf;
     GpioInput gpio(gpioChannel);
@@ -82,6 +84,7 @@ int main(int argc, char *argv[])
     bool gpio_trigger = false;
     bool keyboard_trigger = true;
     bool force_trigger = false;
+    bool use_default_source = true;
 
     QString defaultLang = "en";
     QString defaultKeyboard = "gb";
@@ -127,6 +130,23 @@ int main(int argc, char *argv[])
             if (argc > i+1)
                 defaultPartition = argv[i+1];
         }
+        // Allow default repos to be specified in commandline
+        else if (strcmp(argv[i], "-no_default_source") == 0)
+        {
+             use_default_source = false;
+        }
+        // Allow Extra repos to be specified in commandline
+        else if (strcmp(argv[i], "-alt_image_source") == 0)
+        {
+             if (argc > i+1)
+                extraRepos = argv[i+1];
+        }
+    }
+
+    if (!use_default_source)
+    {
+        defaultRepos = extraRepos;
+        extraRepos = "";
     }
 
     // Intercept right mouse clicks sent to the title bar

--- a/recovery/mainwindow.cpp
+++ b/recovery/mainwindow.cpp
@@ -41,6 +41,9 @@
 #include <QWSServer>
 #endif
 
+extern QString defaultRepos;
+extern QString extraRepos;
+
 /* Main window
  *
  * Initial author: Floris Bos
@@ -935,7 +938,9 @@ void MainWindow::ifupFinished(int)
             _cache->setMaximumCacheSize(8 * 1024 * 1024);
             _netaccess->setCache(_cache);
 
-            downloadList(DEFAULT_REPO_SERVER);
+            _reposNum=0;
+            if (defaultRepos.startsWith("http://"))
+                downloadList(defaultRepos);
         }
         ui->actionBrowser->setEnabled(true);
         emit networkUp();
@@ -1009,6 +1014,11 @@ void MainWindow::downloadListComplete()
     }
 
     reply->deleteLater();
+
+    _reposNum++;
+    if ((_reposNum ==1) && (extraRepos.startsWith("http://")) )
+        downloadList(extraRepos);
+
 }
 
 void MainWindow::processJson(QVariant json)

--- a/recovery/mainwindow.h
+++ b/recovery/mainwindow.h
@@ -49,6 +49,8 @@ protected:
     QNetworkAccessManager *_netaccess;
     int _neededMB, _availableMB, _numMetaFilesToDownload, _numIconsToDownload;
     QMessageBox *_displayModeBox;
+    int _reposNum;
+
 
     QMap<QString,QVariantMap> listImages();
     virtual void changeEvent(QEvent * event);


### PR DESCRIPTION
This modification provides an alternative URL to be specified to download the OS images from. This can be useful for storing the default repository on a local LAN server, or for adding your own list of OSes to those available in NOOBS.

Simply specify the URL of the additional os_list.json file as the argument to the new alt_image_source parameter in recovery.cmdline. e.g. add alt_image_source=http://newurl.com/os_list.json to the end of recovery.cmdline. This source of images will be appended to the default source.

If you only want to use this alternative URL and suppress the default one, add no_default_source to recovery.cmdline. If you specify no_default_source without a corresponding alt_image_source=http://newurl.com/os_list.json argument, then it will disable internet download and only list images available on the SD card.
{replaces PR #234}