### PR TITLE
Modified GPIOtrigger to allow DPI/VGA screens to work

### DIFF
--- a/recovery/main.cpp
+++ b/recovery/main.cpp
@@ -76,10 +76,10 @@ int main(int argc, char *argv[])
 
     QApplication a(argc, argv);
     RightButtonFilter rbf;
-    GpioInput gpio(gpioChannel);
+    GpioInput *gpio = NULL;
 
     bool runinstaller = false;
-    bool gpio_trigger = false;
+
     bool keyboard_trigger = true;
     bool force_trigger = false;
 
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
             runinstaller = true;
         // Enables use of GPIO 3 to force NOOBS to launch by pulling low
         else if (strcmp(argv[i], "-gpiotriggerenable") == 0)
-            gpio_trigger = true;
+            gpio = new GpioInput(gpioChannel);
         // Disables use of keyboard to trigger recovery GUI
         else if (strcmp(argv[i], "-keyboardtriggerdisable") == 0)
             keyboard_trigger = false;
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
     // or no OS is installed (/dev/mmcblk0p5 does not exist)
     bool bailout = !runinstaller
         && !force_trigger
-        && !(gpio_trigger && (gpio.value() == 0 ))
+        && !(gpio && (gpio->value() == 0 ))
         && !(keyboard_trigger && KeyDetection::isF10pressed())
         && QFile::exists(FAT_PARTITION_OF_IMAGE);
 


### PR DESCRIPTION
Using the GPIO pins to trigger NOOBS interferes with the use of the DPI for Gert's VGA666 as it disables the DPI. This modification allows Gert's VGA666 board to be used with NOOBS with the appropriate modifications to config.txt and the addition of dts-blob-dpi.bin.