### PR TITLE
Allow OS maintainer to use their own video mode settings. Fixes #259

### DIFF
--- a/recovery/multiimagewritethread.cpp
+++ b/recovery/multiimagewritethread.cpp
@@ -302,7 +302,8 @@ bool MultiImageWriteThread::processImage(const QString &folder, const QString &f
     Json::saveToFile("/mnt2/os_config.json", qm);
 
     emit statusUpdate(tr("%1: Saving display mode to config.txt").arg(os_name));
-    patchConfigTxt();
+    if ( ! vos.value("managevideo").toBool())
+        patchConfigTxt();
 
     /* Partition setup script can either reside in the image folder
      * or inside the boot partition tarball */


### PR DESCRIPTION
This should resolve #259.

* This lets the OS maintainer define "managevideo": "1" in the os.json file if they wish to handle the video modes.
* If this value is not set, or the value is 0, the old behaviour will be unchanged and the 'videomode' from the QVariantMap will be used to populate the config.txt accordingly.

P.S. Unfortunately, I have not been able to build and test this as my working environment now has Qt 5. Some dependencies, such as QWS can be resolved easily with #ifdefs, but some can not. It would be good if NOOBS could be compiled on the desktop to test it in the future. 

    #ifdef Q_WS_QWS
    #include <QWSServer>
    #endif

