### PR TITLE
Inform the user if more images are available

### DIFF
--- a/recovery/mainwindow.cpp
+++ b/recovery/mainwindow.cpp
@@ -142,6 +142,7 @@ void MainWindow::populate()
         _qpd->setWindowFlags(Qt::Window | Qt::CustomizeWindowHint | Qt::WindowTitleHint);
         _qpd->show();
         QTimer::singleShot(2000, this, SLOT(hideDialogIfNoNetwork()));
+        QTimer::singleShot(2000, this, SLOT(showMoreAvailableDialogIfNoNetwork()));
     }
 
     if (QFile::exists(SETTINGS_PARTITION))
@@ -1469,5 +1470,18 @@ void MainWindow::hideDialogIfNoNetwork()
                                       QMessageBox::Close);
             }
         }
+    }
+}
+
+void MainWindow::showMoreAvailableDialogIfNoNetwork()
+{
+    QByteArray carrier = getFileContents("/sys/class/net/eth0/carrier").trimmed();
+    if (carrier != "1" && ui->list->count() > 0) /* We don't want to show this if hideDialogIfNoNetwork's messagebox showed too */
+    {
+        /* No network cable inserted, but have local images */
+        QMessageBox::information(this,
+                                 tr("More images are available online"),
+                                 tr("A greater variety of more up to date images may be available online. Please insert a network cable in to the network port to access them."),
+                                 QMessageBox::Close);
     }
 }

--- a/recovery/mainwindow.h
+++ b/recovery/mainwindow.h
@@ -87,6 +87,7 @@ protected slots:
     void downloadMetaComplete();
     void onQuery(const QString &msg, const QString &title, QMessageBox::StandardButton* answer);
     void hideDialogIfNoNetwork();
+    void showMoreAvailableDialogIfNoNetwork();
 
 private slots:
     /* UI events */


### PR DESCRIPTION
OSMC was recently added to NOOBS (cheers Andrew).

Lately, we are finding a lot of users are downloading NOOBS Lite and are not plugging in a network cable and thus struggling to find OSMC in NOOBS.

This commit will let the user know of the potential to obtain more operating systems if they connect to the Internet. It makes sure *not* to display the dialog if there are no local images as well -- no point having two dialogs here.

Untested, as on holiday, but *should* work. Famous last words..