### PR TITLE
Fix parted size invocation

### DIFF
--- a/recovery/initdrivethread.cpp
+++ b/recovery/initdrivethread.cpp
@@ -253,7 +253,11 @@ bool InitDriveThread::method_resizePartitions()
         newStartOfRescuePartition = 8192; /* 4 MiB */
     }
 
-    QString cmd = "/usr/sbin/parted --script /dev/mmcblk0 resize 1 "+QString::number(newStartOfRescuePartition)+"s "+QString::number(newSizeOfRescuePartition)+"M";
+    /* Parted needs start & End (not start & size) */
+    /* Convert size from MiB to sectors & add to start to get end position*/
+    int newEndOfRescuePartition =  newStartOfRescuePartition + (newSizeOfRescuePartition * 2048);
+
+    QString cmd = "/usr/sbin/parted --script /dev/mmcblk0 resize 1 "+QString::number(newStartOfRescuePartition)+"s "+QString::number(newEndOfRescuePartition)+"s";
     qDebug() << "Executing" << cmd;
     QProcess p;
     p.setProcessChannelMode(p.MergedChannels);


### PR DESCRIPTION
The use of parted to resize (shrink) the first partition is incorrect. It uses the Start of the rescue partition (in sectors) and the Size of the rescue partition (in MB). It should use the Start and End location of the partition when resizing. I modified the invocation to use the End of the rescue partition (in sectors).

This isn't going to make a lot of difference, since the start of the rescue partition is pretty close to the start of the disk and 4MiB isn't going to eat much into the 100MB buffer that is added. So this change is more for correctness and understandability.