### PR TITLE
Use BACKGROUND_COLOR instead of hardcoded Qt::white

### DIFF
--- a/recovery/main.cpp
+++ b/recovery/main.cpp
@@ -39,7 +39,7 @@
 void reboot_to_extended(const QString &defaultPartition, bool setDisplayMode)
 {
 #ifdef Q_WS_QWS
-    QWSServer::setBackground(Qt::white);
+    QWSServer::setBackground(BACKGROUND_COLOR);
     QWSServer::setCursorVisible(true);
 #endif
     BootSelectionDialog bsd(defaultPartition);


### PR DESCRIPTION
This makes it much easier to alter NOOBS to a black (transparent) background by only adjusting config.h.

I use it like that since version 1.4 since I think it's easier on the eyes...
