### PR TITLE
dhcpcd uses clientid, not duid

### DIFF
--- a/buildroot/package/dhcpcd/dhcpcd.conf
+++ b/buildroot/package/dhcpcd/dhcpcd.conf
@@ -1,0 +1,42 @@
+# A sample configuration for dhcpcd.
+# See dhcpcd.conf(5) for details.
+
+# Allow users of this group to interact with dhcpcd via the control socket.
+#controlgroup wheel
+
+# Inform the DHCP server of our hostname for DDNS.
+hostname
+
+# Use the hardware address of the interface for the Client ID.
+clientid
+# or
+# Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+#duid
+
+# Persist interface configuration when dhcpcd exits.
+persistent
+
+# Rapid commit support.
+# Safe to enable by default because it requires the equivalent option set
+# on the server to actually work.
+option rapid_commit
+
+# A list of options to request from the DHCP server.
+option domain_name_servers, domain_name, domain_search, host_name
+option classless_static_routes
+# Most distributions have NTP support.
+option ntp_servers
+# Respect the network MTU.
+# Some interface drivers reset when changing the MTU so disabled by default.
+#option interface_mtu
+
+# A ServerID is required by RFC2131.
+require dhcp_server_identifier
+
+# Generate Stable Private IPv6 Addresses instead of hardware based ones
+slaac private
+
+# A hook script is provided to lookup the hostname if not set by the DHCP
+# server, but it should not be run by default.
+nohook lookup-hostname
+

--- a/buildroot/package/dhcpcd/dhcpcd.mk
+++ b/buildroot/package/dhcpcd/dhcpcd.mk
@@ -36,9 +36,11 @@ endef
 
 define DHCPCD_INSTALL_TARGET_CMDS
 	$(TARGET_MAKE_ENV) $(MAKE) -C $(@D) install DESTDIR=$(TARGET_DIR)
+	$(INSTALL) -D -m 0664 package/dhcpcd/dhcpcd.conf $(TARGET_DIR)/etc/dhcpcd.conf
 endef
 
 # NOTE: Even though this package has a configure script, it is not generated
 # using the autotools, so we have to use the generic package infrastructure.
 
 $(eval $(generic-package))
+


### PR DESCRIPTION
Uses the `dhcpcd.conf` file copied from Raspbian that uses `clientid` option instead of `duid`. 
Fixes issue #336.
I moved the fix to the dhcpcd package instead of putting it in the recovery package.
An alternative implementation would be to patch the `dhcpcd.conf` file instead of using a completely new version, which would probably make it more robust to future changes. 
