### PR TITLE
Add note about sparse files

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The following steps allow you to create a modified copy of one of the standard O
   1. "partition_size_nominal" - replace the numerical value with the size of the paritions in your custom OS version
   2. "uncompressed_tarball_size" - replace the numerical value with the size of your filesystem tarballs when uncompressed
 
-9. Replace the `.tar.xz` root and boot filesystem tarballs with copies created from your custom OS version (these instructions assume you're only using a single OS at a time with NOOBS - they won't work if you're running multiple OSes from a single SD card). The name of these tarballs needs to match the labels given in `partitions.json`.
+9. Replace the `.tar.xz` root and boot filesystem tarballs with copies created from your custom OS version (these instructions assume you're only using a single OS at a time with NOOBS - they won't work if you're running multiple OSes from a single SD card). The name of these tarballs needs to match the labels given in `partitions.json`. *NB* the version of tar presently used to unpack the tarballs does not support *sparse* files, so it is inadvisable to use the `-S` option of GNU tar, or to use bsdtar, to generate the tarball. 
   1. To create the root tarball you will need to run `tar -cvpf <label>.tar /* --exclude=proc/* --exclude=sys/* --exclude=dev/pts/*` from within the root filesystem of your custom OS version. You should then compress the resulting tarball with `xz -9 -e <label>.tar`.
   2. To create the boot tarball you will need to run `tar -cvpf <label>.tar .` at the root directory of the boot partition of your custom OS version. You should then compress the resulting tarball with `xz -9 -e <label>.tar`.
 


### PR DESCRIPTION
The `tar` implementation used doesn't unpack sparse files correctly, so add a note about this ( we were using bsdtar to generate the archive, and a random file (usr/lib/locale/locale-archive) was for some reason sparse, so it wasn't unpacked currently).