### PR TITLE
Remove initialisation dialog box if network error

### DIFF
--- a/recovery/mainwindow.cpp
+++ b/recovery/mainwindow.cpp
@@ -164,6 +164,8 @@ MainWindow::MainWindow(const QString &defaultDisplay, QSplashScreen *splash, QWi
     {
         _showAll = true;
     }
+
+    _networkOK = true;
     if (cmdline.contains("silentinstall"))
     {
         /* If silentinstall is specified, auto-install single image in /os */
@@ -1067,6 +1069,8 @@ void MainWindow::downloadListComplete()
     {
         if (_qpd)
             _qpd->hide();
+        _networkOK = false;
+
         QMessageBox::critical(this, tr("Download error"), tr("Error downloading distribution list from Internet"), QMessageBox::Close);
     }
     else
@@ -1518,7 +1522,7 @@ void MainWindow::hideDialogIfNoNetwork()
 {
     if (_qpd)
     {
-        if (!isOnline())
+        if (!isOnline() || !_networkOK)
         {
             /* No network cable inserted */
             _qpd->hide();

--- a/recovery/mainwindow.h
+++ b/recovery/mainwindow.h
@@ -47,6 +47,7 @@ protected:
     QSplashScreen *_splash;
     QSettings *_settings;
     bool _hasWifi;
+    bool _networkOK;
     int _numInstalledOS;
     QNetworkAccessManager *_netaccess;
     int _neededMB, _availableMB, _numMetaFilesToDownload, _numIconsToDownload;


### PR DESCRIPTION
Whilst NOOBS is establishing which images are available to install (via local SD card or over the network) it displays the "Please wait while NOOBS initialises" dialog box.

If the Pi is NOT connected to the internet, this box is hidden after a timeout as the network is not up.

If the Pi IS connected to the internet, but there is a problem downloading the distribution file, then the dialog box is hidden and the "Error downloading distribution list from Internet" message box is shown.

However, a problem occurs if the user has the Pi connected to a local network but without access to the download server. Then it is possible that the download error will occur before the local images have even been looked at in populate(). In this situation, the  "Error downloading distribution list from Internet" message box is shown, but the "Please wait while NOOBS initialises" dialog box is never hidden due to this race condition. (It happens to me a lot when I am using it locally connected to my laptop but not the internet)

This pull request fixes this race condition to ensure the dialog box is hidden after the timeout if there was an error downloading the list. I imagine it could be solved in other ways (creating the dialog box earlier for example, but this worked for me.