### PR TITLE
Fix some typos in comments and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ This will also prevent the splashscreen from being displayed at boot. The partit
 ### How to use with the Raspberry Pi Touch Display
 
 If NOOBS detects you are using the [Raspberry Pi Touch Display](https://www.raspberrypi.org/products/raspberry-pi-touch-display/), it will enable the following functionality:
-- A tap on the touchscreen can activate NOOBS aswell as holding the shift key down.
+- A tap on the touchscreen can activate NOOBS as well as holding the shift key down.
 - A tap on the touchscreen will simulate a mouse click
 - A longpress on the touchscreen will simulate a mouse double-click.
 

--- a/recovery/config.h
+++ b/recovery/config.h
@@ -37,7 +37,7 @@
 /* Partitioning settings */
 #define PARTITION_ALIGNMENT  8192
 #define PARTITION_GAP  2
-/* Allow partitions to be shrinked PARTITION_GAP sectors
+/* Allow partitions to be shrunk PARTITION_GAP sectors
    if that prevents having a 4 MiB gap between the next one */
 #define SHRINK_PARTITIONS_TO_MINIMIZE_GAPS
 

--- a/recovery/mainwindow.cpp
+++ b/recovery/mainwindow.cpp
@@ -721,7 +721,7 @@ void MainWindow::displayMode(int modenr, bool silent)
     QWSServer::instance()->refresh();
 
     // In case they can't see the message box, inform that mode change
-    // is occuring by turning on the LED during the change
+    // is occurring by turning on the LED during the change
     QProcess *led_blink = new QProcess(this);
     connect(led_blink, SIGNAL(finished(int)), led_blink, SLOT(deleteLater()));
     led_blink->start("sh -c \"echo 1 > /sys/class/leds/led0/brightness; sleep 3; echo 0 > /sys/class/leds/led0/brightness\"");

--- a/recovery/wifisettingsdialog.cpp
+++ b/recovery/wifisettingsdialog.cpp
@@ -159,7 +159,7 @@ void WifiSettingsDialog::on_passwordRadio_toggled(bool checked)
 
 void WifiSettingsDialog::on_list_currentItemChanged(QListWidgetItem *current)
 {
-    /* Enable authentication options appropiate for the SSID selected */
+    /* Enable authentication options appropriate for the SSID selected */
     QVariantMap properties = current->data(Qt::UserRole).toMap();
     QStringList keymgmt = properties.value("WPA").toMap().value("KeyMgmt").toStringList();
     QStringList keymgmt_wpa2 = properties.value("RSN").toMap().value("KeyMgmt").toStringList();


### PR DESCRIPTION
All of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>