### PR TITLE
Copy ssh for Raspbian

### DIFF
--- a/recovery/multiimagewritethread.cpp
+++ b/recovery/multiimagewritethread.cpp
@@ -491,6 +491,17 @@ bool MultiImageWriteThread::processImage(OsInfo *image)
     emit statusUpdate(tr("%1: Saving display mode to config.txt").arg(os_name));
     patchConfigTxt();
 
+    /* enable SSH
+     * If user supplied a ssh on the FAT partition copy that to partition1 (boot)
+     */
+    if (os_name == RECOMMENDED_IMAGE)
+    {
+        if (QFile::exists("/mnt/ssh"))
+        {
+            QFile::copy("/mnt/ssh", "/mnt2/ssh");
+        }
+    }
+
     /* Partition setup script can either reside in the image folder
      * or inside the boot partition tarball */
     QString postInstallScript = image->folder()+"/partition_setup.sh";


### PR DESCRIPTION
This patch will fix the NOOBS issue created by disabling ssh by default in Raspbian.
It allows a user to put a blank ssh file on the recovery partition, which NOOBS will copy to the /boot partition, but only for Raspbian. The first IF statement could be removed to allow it to work with all OSes.

Without this it is difficult to do a headless Raspbian install using NOOBS and get ssh working, although I did post some other workarounds for this on the forums. This makes the process the same for both a NOOBS and an image install of Raspbian.