### PR TITLE
Add folder to specified tarball

### DIFF
--- a/recovery/multiimagewritethread.cpp
+++ b/recovery/multiimagewritethread.cpp
@@ -388,6 +388,16 @@ bool MultiImageWriteThread::processImage(OsInfo *image)
                 return false;
             }
         }
+        else if (!emptyfs && !isURL(tarball))
+        {
+            /* non-URL tarball is specified */
+            if (!tarball.contains("/"))
+            {
+                /* Assume just the filename was specified, so add the path */
+                tarball = image->folder()+"/"+tarball;
+            }
+        }
+
         if (label.size() > 15)
         {
             label.clear();


### PR DESCRIPTION
The `tarball` field is used to specify an external URL to download an image from. Often these external images do not have the default filename of `partition.tar.xz`. If `tarball` is absent, the image is assumed to be local and have the same name as the partition (e.g. `root.tar.xz`). But it could equally specify a different local image filename rather than the default, but in this case the complete path must be used (and therefore known).

This PR adds the image folder to the tarball if one does not already exist, so that alternative image filenames can be specified and found in their correct location (Useful if you want to have a local copy of one of these images in your SDcard /os folder without having to change the name to the default)