### PR TITLE
added url parsing to allow query params in urls

### DIFF
--- a/recovery/multiimagewritethread.cpp
+++ b/recovery/multiimagewritethread.cpp
@@ -12,6 +12,7 @@
 #include <QProcessEnvironment>
 #include <QSettings>
 #include <QTime>
+#include <QUrl>
 #include <unistd.h>
 #include <linux/fs.h>
 #include <linux/magic.h>
@@ -719,26 +720,29 @@ bool MultiImageWriteThread::untar(const QString &tarball)
 {
     QString cmd = "sh -o pipefail -c \"";
 
-    if (isURL(tarball))
+    QString tarballPath = QString(tarball);
+    if (isURL(tarball)){
+        tarballPath = QUrl::fromUserInput(tarball).toString(QUrl::RemoveQuery);
         cmd += "wget --no-verbose --tries=inf -O- "+tarball+" | ";
+    }
 
-    if (tarball.endsWith(".gz"))
+    if (tarballPath.endsWith(".gz"))
     {
         cmd += "gzip -dc";
     }
-    else if (tarball.endsWith(".xz"))
+    else if (tarballPath.endsWith(".xz"))
     {
         cmd += "xz -dc";
     }
-    else if (tarball.endsWith(".bz2"))
+    else if (tarballPath.endsWith(".bz2"))
     {
         cmd += "bzip2 -dc";
     }
-    else if (tarball.endsWith(".lzo"))
+    else if (tarballPath.endsWith(".lzo"))
     {
         cmd += "lzop -dc";
     }
-    else if (tarball.endsWith(".zip"))
+    else if (tarballPath.endsWith(".zip"))
     {
         /* Note: the image must be the only file inside the .zip */
         cmd += "unzip -p";


### PR DESCRIPTION
Url is now parsed and query params are removed when checking for file extension.

The remaining issue is if someone would use query params to specify the file like `htttps://mysditribution.com/download?file=root.tar.xz`

What do you think ?
