### PR TITLE
Fix instructions to create custom OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The following steps allow you to create a modified copy of one of the standard O
   2. "uncompressed_tarball_size" - replace the numerical value with the size of your filesystem tarballs when uncompressed
 
 9. Replace the `.tar.xz` root and boot filesystem tarballs with copies created from your custom OS version (these instructions assume you're only using a single OS at a time with NOOBS - they won't work if you're running multiple OSes from a single SD card). The name of these tarballs needs to match the labels given in `partitions.json`.
-  1. To create the root tarball you will need to run `tar -cvpf <label>.tar /* --exclude=proc/* --exclude=sys/* --exclude=dev/pts/*` from within the root filesystem of your custom OS version. You should then compress the resulting tarball with `xz -9 -e <label>.tar`.
+  1. To create the root tarball you will need to run `tar -cvpf <label>.tar /* --exclude=./proc/* --exclude=./sys/* --exclude=./dev/pts/*` from within the root filesystem of your custom OS version. You should then compress the resulting tarball with `xz -9 -e <label>.tar`.
   2. To create the boot tarball you will need to run `tar -cvpf <label>.tar .` at the root directory of the boot partition of your custom OS version. You should then compress the resulting tarball with `xz -9 -e <label>.tar`.
 
 ### How to change the default Language, Keyboard layout, Display mode or Boot Partition etc.

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ The following steps allow you to create a modified copy of one of the standard O
   2. "uncompressed_tarball_size" - replace the numerical value with the size of your filesystem tarballs when uncompressed
 
 9. Replace the `.tar.xz` root and boot filesystem tarballs with copies created from your custom OS version (these instructions assume you're only using a single OS at a time with NOOBS - they won't work if you're running multiple OSes from a single SD card). The name of these tarballs needs to match the labels given in `partitions.json`.
-  1. To create the root tarball you will need to run `tar -cvpf <label>.tar /* --exclude=./proc/* --exclude=./sys/* --exclude=./dev/pts/*` from within the root filesystem of your custom OS version. You should then compress the resulting tarball with `xz -9 -e <label>.tar`.
-  2. To create the boot tarball you will need to run `tar -cvpf <label>.tar .` at the root directory of the boot partition of your custom OS version. You should then compress the resulting tarball with `xz -9 -e <label>.tar`.
+  1. To create the root tarball you will need to run `bsdtar --numeric-owner --format gnutar --one-file-system -cpf <label>.tar .` from within the root filesystem of your custom OS version. You should then compress the resulting tarball with `xz -9 -e <label>.tar`.
+  2. To create the boot tarball you will need to run `bsdtar --numeric-owner --format gnutar -cpf <label>.tar .` at the root directory of the boot partition of your custom OS version. You should then compress the resulting tarball with `xz -9 -e <label>.tar`.
 
 ### How to change the default Language, Keyboard layout, Display mode or Boot Partition etc.
 


### PR DESCRIPTION
The instructions for creating a custom OS have an error when compressing the root partition. By not anchoring the exclusions in the root directory of the rootfs, it can exclude some other folders elsewhere in the filesystem tree, causing problems when the OS is later installed.

I prefixed the excluded file patterns with `./` to anchor them, as was the original intention.