### PR TITLE
Shorten partition label names according to fstype

### DIFF
--- a/recovery/multiimagewritethread.h
+++ b/recovery/multiimagewritethread.h
@@ -20,6 +20,8 @@ public:
 protected:
     virtual void run();
     bool processImage(OsInfo *image);
+    QString shorten(QString example, int maxLabelLen);
+    QByteArray makeLabelUnique(QByteArray label, int maxLabelLen);
     bool mkfs(const QByteArray &device, const QByteArray &fstype = "ext4", const QByteArray &label = "", const QByteArray &mkfsopt = "");
     bool dd(const QString &imagePath, const QString &device);
     bool partclone_restore(const QString &imagePath, const QString &device);


### PR DESCRIPTION
If a partition label is specified that is >15 characters in length, NOOBS will unilaterally erase it.
This PR will shorten the partition label to the appropriate size for the file system instead: 11 for FAT, 16 for ext4 and 32 for NTFS. It will then make the label unique if necessary.

The shorten() function tries to make a sensible partition label out of one that has several distinct parts. If this is not required, the call can be replaced by something like `label = label.left(maxLabelLen);`

Fixes one issue from #456.