### PR TITLE
Account for IOaccounting on multiDrives

### DIFF
--- a/recovery/mainwindow.cpp
+++ b/recovery/mainwindow.cpp
@@ -1583,6 +1583,7 @@ void MainWindow::startImageWrite()
     connect(imageWriteThread, SIGNAL(statusUpdate(QString)), _qpd, SLOT(setLabelText(QString)));
     connect(imageWriteThread, SIGNAL(runningMKFS()), _qpd, SLOT(pauseIOaccounting()), Qt::BlockingQueuedConnection);
     connect(imageWriteThread, SIGNAL(finishedMKFS()), _qpd , SLOT(resumeIOaccounting()), Qt::BlockingQueuedConnection);
+    connect(imageWriteThread, SIGNAL(newDrive(const QString&)), _qpd , SLOT(changeDrive(const QString&)), Qt::BlockingQueuedConnection);
     imageWriteThread->start();
     hide();
     _qpd->exec();

--- a/recovery/multiimagewritethread.cpp
+++ b/recovery/multiimagewritethread.cpp
@@ -465,6 +465,7 @@ bool MultiImageWriteThread::processImage(OsInfo *image)
             }
         }
         QByteArray partdevice = p->partitionDevice();
+        emit newDrive(partdevice);
 
         if (fstype == "raw")
         {

--- a/recovery/multiimagewritethread.h
+++ b/recovery/multiimagewritethread.h
@@ -50,7 +50,8 @@ signals:
     void completed();
     void runningMKFS();
     void finishedMKFS();
-    
+    void newDrive(const QString&);
+
 public slots:
     
 };

--- a/recovery/progressslideshowdialog.cpp
+++ b/recovery/progressslideshowdialog.cpp
@@ -123,6 +123,13 @@ void ProgressSlideshowDialog::resumeIOaccounting()
     _iotimer.start(1000);
 }
 
+void ProgressSlideshowDialog::changeDrive(const QString &drive)
+{
+    pauseIOaccounting();
+    _drive = drive;
+    resumeIOaccounting();
+}
+
 void ProgressSlideshowDialog::setMaximum(qint64 bytes)
 {
     _maxSectors = bytes/512;

--- a/recovery/progressslideshowdialog.h
+++ b/recovery/progressslideshowdialog.h
@@ -35,6 +35,7 @@ public slots:
     void updateIOstats();
     void pauseIOaccounting();
     void resumeIOaccounting();
+    void changeDrive(const QString &drive);
 
 protected:
     QString _drive;


### PR DESCRIPTION
The progressSlideShowDialog shows the progress of installation by monitoring the number of sectors written to the installation _drive. However, now that an OS rootfs can be written to a USB drive, any sectors written to the _bootDrive are not accounted for. This is very noticeable for an OS like LibreELEC where ALL of the image is written to the boot partition and the rootfs is purely used for storage, so the progress bar hardly moves during installation.

This PR fixes this by allowing the drive that is being monitored to be changed during the installation of the various partitions.

Fixes #459