### PR TITLE
Change wpa_supplicant copy

### DIFF
--- a/recovery/mainwindow.cpp
+++ b/recovery/mainwindow.cpp
@@ -973,13 +973,13 @@ void MainWindow::copyWpa()
         QProcess::execute("mount -o remount,rw /settings");
         QProcess::execute("mount -o remount,rw /mnt");
 
-        backup("/settings/wpa_supplicant.conf");
+        backupFile("/settings/wpa_supplicant.conf");
         QFile::copy("/mnt/wpa_supplicant.conf", "/settings/wpa_supplicant.conf");
         f.setPermissions( QFile::WriteUser | QFile::ReadGroup | QFile::ReadOther | QFile::ReadUser );
 
 	/* rename the user file to indicate that it has been copied (and prevent it being re-copied next time, 
            which could potentially overwrite any SSIDs created in the NOOBS GUI) */
-	backup("/mnt/wpa_supplicant.conf");
+	backupFile("/mnt/wpa_supplicant.conf");
 
         QProcess::execute("sync");
         QProcess::execute("mount -o remount,ro /settings");

--- a/recovery/mainwindow.cpp
+++ b/recovery/mainwindow.cpp
@@ -216,7 +216,7 @@ MainWindow::MainWindow(const QString &drive, const QString &defaultDisplay, QSpl
         _fixate = true;
     }
 
-    copywpa();
+    copyWpa();
 
     if (cmdline.contains("silentinstall"))
     {
@@ -954,6 +954,7 @@ void MainWindow::on_list_doubleClicked(const QModelIndex &index)
     }
 }
 
+
 void MainWindow::copyWpa()
 {
     //This file is the one used by dhcpcd
@@ -967,19 +968,18 @@ void MainWindow::copyWpa()
     /* If user supplied a wpa_supplicant.conf on the FAT partition copy that one to settings regardless */
     if (QFile::exists("/mnt/wpa_supplicant.conf"))
     {
-        qDebug() << "Copying  user wpa_supplicant.conf to /settings/wpa_supplicant.conf";
+        qDebug() << "Copying user wpa_supplicant.conf to /settings/wpa_supplicant.conf";
 
         QProcess::execute("mount -o remount,rw /settings");
         QProcess::execute("mount -o remount,rw /mnt");
 
-        QFile::remove("/settings/wpa_supplicant.conf.bak");
-        QFile::rename("/settings/wpa_supplicant.conf","/settings/wpa_supplicant.conf.bak");
+        backup("/settings/wpa_supplicant.conf");
         QFile::copy("/mnt/wpa_supplicant.conf", "/settings/wpa_supplicant.conf");
         f.setPermissions( QFile::WriteUser | QFile::ReadGroup | QFile::ReadOther | QFile::ReadUser );
 
-        /* rename the user file to avoid overwriting any manually set SSIDs */
-        QFile::remove("/mnt/wpa_supplicant.conf.bak");
-        QFile::rename("/mnt/wpa_supplicant.conf","/mnt/wpa_supplicant.conf.bak");
+	/* rename the user file to indicate that it has been copied (and prevent it being re-copied next time, 
+           which could potentially overwrite any SSIDs created in the NOOBS GUI) */
+	backup("/mnt/wpa_supplicant.conf");
 
         QProcess::execute("sync");
         QProcess::execute("mount -o remount,ro /settings");

--- a/recovery/mainwindow.h
+++ b/recovery/mainwindow.h
@@ -78,6 +78,7 @@ protected:
     bool isSupportedOs(const QString &name, const QVariantMap &values);
     void addImagesFromUSB(const QString &device);
     void filterList();
+    void copyWpa();
 
 protected slots:
     void populate();

--- a/recovery/util.cpp
+++ b/recovery/util.cpp
@@ -39,6 +39,17 @@ void putFileContents(const QString &filename, const QByteArray &data)
     f.close();
 }
 
+bool backup(QString filename, QString ext)
+{
+
+    QString backupName = filename + "." + ext;
+    const char * backupFile = backupName.toUtf8().constData();
+    if( access( backupFile, F_OK ) != -1 ) {
+        remove(backupFile);
+    }
+    return rename(filename.toUtf8().constData(), backupFile);
+}
+
 /* Utility function to query current overscan setting */
 #define VCMSG_GET_OVERSCAN 0x0004000a
 #define VCMSG_SET_OVERSCAN 0x0004800a

--- a/recovery/util.cpp
+++ b/recovery/util.cpp
@@ -39,7 +39,7 @@ void putFileContents(const QString &filename, const QByteArray &data)
     f.close();
 }
 
-bool backup(const QString &filename, const QString &ext)
+bool backupFile(const QString &filename, const QString &ext)
 {
     QString backupName = filename + "." + ext;
 

--- a/recovery/util.cpp
+++ b/recovery/util.cpp
@@ -39,15 +39,15 @@ void putFileContents(const QString &filename, const QByteArray &data)
     f.close();
 }
 
-bool backup(QString filename, QString ext)
+bool backup(const QString &filename, const QString &ext)
 {
-
     QString backupName = filename + "." + ext;
-    const char * backupFile = backupName.toUtf8().constData();
-    if( access( backupFile, F_OK ) != -1 ) {
-        remove(backupFile);
+
+    if (QFile::exists(backupName))
+    {
+        QFile::remove(backupName);
     }
-    return rename(filename.toUtf8().constData(), backupFile);
+    return  QFile::rename(filename,backupName);
 }
 
 /* Utility function to query current overscan setting */

--- a/recovery/util.h
+++ b/recovery/util.h
@@ -16,7 +16,7 @@
 
 QByteArray getFileContents(const QString &filename);
 void putFileContents(const QString &filename, const QByteArray &data);
-bool backup(const QString &filename, const QString &ext="bak");
+bool backupFile(const QString &filename, const QString &ext="bak");
 void getOverscan(int &top, int &bottom, int &left, int &right);
 bool nameMatchesRiscOS(const QString &name);
 uint readBoardRevision();

--- a/recovery/util.h
+++ b/recovery/util.h
@@ -16,7 +16,7 @@
 
 QByteArray getFileContents(const QString &filename);
 void putFileContents(const QString &filename, const QByteArray &data);
-bool backup(QString filename, QString ext="bak");
+bool backup(const QString &filename, const QString &ext="bak");
 void getOverscan(int &top, int &bottom, int &left, int &right);
 bool nameMatchesRiscOS(const QString &name);
 uint readBoardRevision();

--- a/recovery/util.h
+++ b/recovery/util.h
@@ -16,6 +16,7 @@
 
 QByteArray getFileContents(const QString &filename);
 void putFileContents(const QString &filename, const QByteArray &data);
+bool backup(QString filename, QString ext="bak");
 void getOverscan(int &top, int &bottom, int &left, int &right);
 bool nameMatchesRiscOS(const QString &name);
 uint readBoardRevision();


### PR DESCRIPTION
To fix #341 part 1.
Diff makes this look more complicated than it is.
Essentially the copy of wpa_supplicant.conf has been taken out of startNetwokring() into copywpa() which is then called ahead of startNetworking() regardless of silentinstall option.
Then copywpa() was modified to provide the necessary functionality.

(This PR is a copy/paste out of PINN into NOOBS)
