### PR TITLE
Automatic keyboard layout change for Swedish

### DIFF
--- a/recovery/languagedialog.cpp
+++ b/recovery/languagedialog.cpp
@@ -182,6 +182,10 @@ void LanguageDialog::changeLanguage(const QString &langcode)
     {
         defaultKeyboardLayout = "jp";
     }
+    else if (langcode == "sv")
+    {
+        defaultKeyboardLayout = "se";
+    }
     else
     {
         defaultKeyboardLayout = langcode;


### PR DESCRIPTION
Added if statement to languagedialog.cpp in the same way as for
Japanese to automatically switch to Swedish keyboard layout
when Swedish language is chosen.

This is the same change as in commit f3b6970 of pull request #252