### PR TITLE
Less restrictive search for NOOBS files

### DIFF
--- a/recovery/main.cpp
+++ b/recovery/main.cpp
@@ -81,9 +81,8 @@ QString findRecoveryDrive()
 
     foreach (QString devname, list)
     {
-        /* Only search first partition and partitionless devices. Skip virtual devices (such as ramdisk) */
-        if ((devname.right(1).at(0).isDigit() && !devname.endsWith("1"))
-                || QFile::symLinkTarget("/sys/class/block/"+devname).contains("/devices/virtual/"))
+        /* Skip virtual devices (such as ramdisk) */
+        if (QFile::symLinkTarget("/sys/class/block/"+devname).contains("/devices/virtual/"))
             continue;
 
         if (QProcess::execute("mount -t vfat -o ro /dev/"+devname+" /mnt") == 0)

--- a/recovery/main.cpp
+++ b/recovery/main.cpp
@@ -81,9 +81,31 @@ QString findRecoveryDrive()
 
     foreach (QString devname, list)
     {
-        /* Skip virtual devices (such as ramdisk) */
-        if (QFile::symLinkTarget("/sys/class/block/"+devname).contains("/devices/virtual/"))
+        if (QFile::symLinkTarget("/sys/class/block/"+devname).contains("/devices/virtual/") )
+        {   //Skip if partition is virtual.
             continue;
+        }
+
+        int partitionNr = 0;
+        QRegExp partnrRx("([0-9]+)$");
+        if (partnrRx.indexIn(devname) != -1)
+        {   //Does devname end in 1 or more digits? Yes->Read it
+            partitionNr = partnrRx.cap(1).toInt();
+
+            if (partitionNr>1)
+            {   //Skip if partition Number >1
+                continue;
+            }
+        }
+
+        if (partitionNr == 0)
+        {   //Check for a possible non-MBR drive
+            if ( list.contains(devname+"1") || list.contains(devname+"p1") )
+            {
+                //skip if partition 1 exists (must have MBR)
+                continue;
+            }
+        }
 
         if (QProcess::execute("mount -t vfat -o ro /dev/"+devname+" /mnt") == 0)
         {
@@ -106,10 +128,8 @@ QString findRecoveryDrive()
         if (!drive.isEmpty())
             break;
     }
-
-    return drive;
+    return(drive);
 }
-
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Fixes #498 

This removes some restrictions on the drives that NOOBS will search for its files to determine the boot drive.
In this way it will detect NOOBS on a superfloppy drive that has no MBR and will allow it to be partitioned and formatted properly.

I produced some test images to prove it works.

https://sourceforge.net/projects/pinn/files/testing/superfloppy.zip/download is an image file that should be flashed to a blank SD card with Balena Etcher. It contains NOOBS 3.0 on a superfloppy formatted partition. When it boots, it will not detect the NOOBS files.

https://sourceforge.net/projects/pinn/files/testing/superfloppyfix.zip/download is an image file that should be flashed to a blank SD card with Balena Etcher. It is the same as the previous image, except I replaced recovery.rfs with a version of NOOBS recovery program with this pull request in. It shows that the drive will be detected, partitioned and formatted correctly.



