### PR TITLE
Document that display must connect to HDMI0 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The NOOBS interface provides the following functionality:
 Note that all user settings (language, keyboard layout, display mode) will persist between reboots and will also be automatically passed to the installed OSes. This means that if you can see the NOOBS interface on your display device then you should be able to see the OS CLI/GUI when it boots too!
 ### Setup
 
+**Raspberry Pi 4 Model B:** display must be connected to HDMI port closest to power jack.
+
 To set up a blank SD card with NOOBS:
 - Format an SD card that is 8GB or greater in size as FAT32 (see instructions on how to do this below)
 - Download and extract the files from the NOOBS zip file. (Windows built-in zip features may have trouble with this file. If so, use another program such as [7zip](http://www.7-zip.org/).)

--- a/sdcontent/INSTRUCTIONS-README.txt
+++ b/sdcontent/INSTRUCTIONS-README.txt
@@ -22,6 +22,8 @@ NOOBS INSTALLATION INSTRUCTIONS
 4. Copy the extracted files onto the SD card that you just formatted so that this file is at the root directory of the SD card. Please note that in some cases it may extract the files into a folder, if this is the case then please copy across the files from inside the folder rather than the folder itself.
 5. Insert the SD card into your Pi and connect the power supply.
 
+**Raspberry Pi 4 Model B:** display must be connected to HDMI port closest to power jack.
+
 Your Pi will now boot into NOOBS and should display a list of operating systems that you can choose to install.
 If your display remains blank, you should select the correct output mode for your display by pressing one of the following number keys on your keyboard:
 1. HDMI mode - this is the default display mode.


### PR DESCRIPTION
While  Dual video is not enabled (github #572) for Pi 4B, warn which HDMI port must be used (github #577)