### PR TITLE
Fix certificate errors

### DIFF
--- a/buildroot/package/arora/arora-fix-cert-errors.patch
+++ b/buildroot/package/arora/arora-fix-cert-errors.patch
@@ -1,0 +1,125 @@
+--- /dev/null
++++ b/src/network/certfix.cpp
+@@ -0,0 +1,103 @@
++/****************************************************************************
++**
++** Copyright (C) 2017 The Qt Company Ltd.
++** Copyright (C) 2014 Governikus GmbH & Co. KG
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the QtNetwork module of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++/****************************************************************************
++**
++** In addition, as a special exception, the copyright holders listed above give
++** permission to link the code of its release of Qt with the OpenSSL project's
++** "OpenSSL" library (or modified versions of the "OpenSSL" library that use the
++** same license as the original version), and distribute the linked executables.
++**
++** You must comply with the GNU General Public License version 2 in all
++** respects for all of the code used other than the "OpenSSL" code.  If you
++** modify this file, you may extend this exception to your version of the file,
++** but you are not obligated to do so.  If you do not wish to do so, delete
++** this exception statement from your version of this file.
++**
++****************************************************************************/
++
++#include <QDirIterator>
++#include <QDir>
++#include <qsslconfiguration.h>
++#include <qsslerror.h>
++
++QList<QByteArray> unixRootCertDirectories_backport()
++{
++    return QList<QByteArray>() <<  "/etc/ssl/certs/" // (K)ubuntu, OpenSUSE, Mandriva ...
++                               << "/usr/lib/ssl/certs/" // Gentoo, Mandrake
++                               << "/usr/share/ssl/" // Centos, Redhat, SuSE
++                               << "/usr/local/ssl/" // Normal OpenSSL Tarball
++                               << "/var/ssl/certs/" // AIX
++                               << "/usr/local/ssl/certs/" // Solaris
++                               << "/etc/openssl/certs/" // BlackBerry
++                               << "/opt/openssl/certs/" // HP-UX
++                               << "/etc/ssl/"; // OpenBSD
++}
++
++QList<QSslCertificate> systemCaCertificates_backport()
++{
++    QList<QSslCertificate> systemCerts;
++    QSet<QString> certFiles;
++    QDir currentDir;
++    QStringList nameFilters;
++    QList<QByteArray> directories;
++    QSsl::EncodingFormat platformEncodingFormat;
++    directories = unixRootCertDirectories_backport();
++    nameFilters << QLatin1String("*.pem") << QLatin1String("*.crt");
++    platformEncodingFormat = QSsl::Pem;
++    {
++        currentDir.setNameFilters(nameFilters);
++        for (int a = 0; a < directories.count(); a++) {
++            currentDir.setPath(QLatin1String(directories.at(a)));
++            QDirIterator it(currentDir);
++            while (it.hasNext()) {
++                it.next();
++                // use canonical path here to not load the same certificate twice if symlinked
++                certFiles.insert(it.fileInfo().canonicalFilePath());
++            }
++        }
++        for (const QString& file : qAsConst(certFiles))
++            systemCerts.append(QSslCertificate::fromPath(file, platformEncodingFormat));
++        systemCerts.append(QSslCertificate::fromPath(QLatin1String("/etc/pki/tls/certs/ca-bundle.crt"), QSsl::Pem)); // Fedora, Mandriva
++        systemCerts.append(QSslCertificate::fromPath(QLatin1String("/usr/local/share/certs/ca-root-nss.crt"), QSsl::Pem)); // FreeBSD's ca_root_nss
++    }
++
++    return systemCerts;
++}
+--- a/src/network/networkaccessmanager.cpp
++++ b/src/network/networkaccessmanager.cpp
+@@ -88,6 +88,8 @@
+ #include <qsslerror.h>
+ #include <qdatetime.h>
+ 
++#include "certfix.cpp"
++
+ // #define NETWORKACCESSMANAGER_DEBUG
+ 
+ NetworkAccessManager::NetworkAccessManager(QObject *parent)
+@@ -164,6 +166,7 @@ void NetworkAccessManager::loadSettings()
+ 
+ #ifndef QT_NO_OPENSSL
+     QSslConfiguration sslCfg = QSslConfiguration::defaultConfiguration();
++    sslCfg.setCaCertificates(systemCaCertificates_backport());
+     QList<QSslCertificate> ca_list = sslCfg.caCertificates();
+     QList<QSslCertificate> ca_new = QSslCertificate::fromData(settings.value(QLatin1String("CaCertificates")).toByteArray());
+     ca_list += ca_new;

--- a/buildroot/package/ca-certificates/Config.in
+++ b/buildroot/package/ca-certificates/Config.in
@@ -6,6 +6,7 @@ config BR2_PACKAGE_CA_CERTIFICATES
 	  connections.
 
 	  It includes, among others, certificate authorities used by the
-	  Debian infrastructure and those shipped with Mozilla's browsers.
+	  Debian infrastructure and those shipped with Mozilla's
+	  browsers.
 
-	  http://anonscm.debian.org/gitweb/?p=collab-maint/ca-certificates.git
+	  https://salsa.debian.org/debian/ca-certificates

--- a/buildroot/package/ca-certificates/ca-certificates.hash
+++ b/buildroot/package/ca-certificates/ca-certificates.hash
@@ -1,3 +1,6 @@
 # hashes from: $(CA_CERTIFICATES_SITE)/ca-certificates_$(CA_CERTIFICATES_VERSION).dsc :
-sha1   6013ce6a3bf13e73a7e1feddcd17f5b2c09e5bd3                         ca-certificates_20141019.tar.xz
-sha256 684902d3f4e9ad27829f4af0d9d2d588afed03667997579b9c2be86fcd1eb73a ca-certificates_20141019.tar.xz
+sha1   47d4584eae85fc905e4994766eb3930a8a84e2e1                         ca-certificates_20190110.tar.xz
+sha256 ee4bf0f4c6398005f5b5ca4e0b87b82837ac5c3b0280a1cb3a63c47555c3a675 ca-certificates_20190110.tar.xz
+
+# Locally computed
+sha256 80fd11117df5543d5cf17bfd951b0ead213f7867d0b09f09c6d5a5eca3ff7422 debian/copyright

--- a/buildroot/package/ca-certificates/ca-certificates.mk
+++ b/buildroot/package/ca-certificates/ca-certificates.mk
@@ -4,34 +4,40 @@
 #
 ################################################################################
 
-CA_CERTIFICATES_VERSION = 20141019
+CA_CERTIFICATES_VERSION = 20190110
 CA_CERTIFICATES_SOURCE = ca-certificates_$(CA_CERTIFICATES_VERSION).tar.xz
-CA_CERTIFICATES_SITE = http://snapshot.debian.org/archive/debian/20141023T043132Z/pool/main/c/ca-certificates
+CA_CERTIFICATES_SITE = http://snapshot.debian.org/archive/debian/20190513T145054Z/pool/main/c/ca-certificates
 CA_CERTIFICATES_DEPENDENCIES = host-openssl host-python
-CA_CERTIFICATES_LICENSE = GPLv2+ (script), MPLv2.0 (data)
+CA_CERTIFICATES_LICENSE = GPL-2.0+ (script), MPL-2.0 (data)
 CA_CERTIFICATES_LICENSE_FILES = debian/copyright
 
 define CA_CERTIFICATES_BUILD_CMDS
-	$(TARGET_MAKE_ENV) $(MAKE) -C $(@D) all
+	$(TARGET_MAKE_ENV) $(MAKE) -C $(@D) clean all
 endef
 
 define CA_CERTIFICATES_INSTALL_TARGET_CMDS
 	$(INSTALL) -d -m 0755 $(TARGET_DIR)/usr/share/ca-certificates
 	$(INSTALL) -d -m 0755 $(TARGET_DIR)/etc/ssl/certs
-	$(MAKE) -C $(@D) install DESTDIR=$(TARGET_DIR)
+	$(TARGET_MAKE_ENV) $(MAKE) -C $(@D) install DESTDIR=$(TARGET_DIR)
 	rm -f $(TARGET_DIR)/usr/sbin/update-ca-certificates
 
 	# Remove any existing certificates under /etc/ssl/certs
 	rm -f  $(TARGET_DIR)/etc/ssl/certs/*
 
 	# Create symlinks to certificates under /etc/ssl/certs
+	# and generate the bundle
 	cd $(TARGET_DIR) ;\
-	for i in `find usr/share/ca-certificates -name "*.crt"` ; do \
+	for i in `find usr/share/ca-certificates -name "*.crt" | LC_COLLATE=C sort` ; do \
 		ln -sf ../../../$$i etc/ssl/certs/`basename $${i} .crt`.pem ;\
-	done
+		cat $$i ;\
+	done >$(@D)/ca-certificates.crt
 
 	# Create symlinks to the certificates by their hash values
 	$(HOST_DIR)/usr/bin/c_rehash $(TARGET_DIR)/etc/ssl/certs
+
+	# Install the certificates bundle
+	$(INSTALL) -D -m 644 $(@D)/ca-certificates.crt \
+		$(TARGET_DIR)/etc/ssl/certs/ca-certificates.crt
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
This fixes many "invalid certificate" errors in Arora by backporting a QT 5 feature (the way Arora normally gets system certificates is broken in QT) and updating included certificates.