### PR TITLE
Added PS1 profile

### DIFF
--- a/buildroot/package/recovery/profile
+++ b/buildroot/package/recovery/profile
@@ -1,0 +1,2 @@
+export PS1="\u@\h:\w# "
+

--- a/buildroot/package/recovery/recovery.mk
+++ b/buildroot/package/recovery/recovery.mk
@@ -33,6 +33,8 @@ define RECOVERY_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 package/recovery/unicode-fonts/NanumBarunGothicBold.ttf $(TARGET_DIR)/usr/lib/fonts/NanumBarunGothicBold.ttf
 	$(INSTALL) -m 0755 package/recovery/data/data $(TARGET_DIR)/usr/data
 	$(INSTALL) -m 0644 $(@D)/cmdline.txt $(BINARIES_DIR)/cmdline.txt
+	$(INSTALL) -m 0755 package/recovery/profile  $(TARGET_DIR)/root/.profile
+
 	mkdir -p $(TARGET_DIR)/keymaps/
 	$(INSTALL) -m 0755 package/recovery/keymaps/* $(TARGET_DIR)/keymaps/
 	$(INSTALL) -m 0644 package/recovery/wpa_supplicant.conf $(TARGET_DIR)/etc/wpa_supplicant.conf


### PR DESCRIPTION
Adds a more usual shell PS1 prompt, including user, host and working dir, instead of just '#'.
(separated from dualhdmi PR)