### PR TITLE
Prevent closing progress dialog

### DIFF
--- a/recovery/progressslideshowdialog.cpp
+++ b/recovery/progressslideshowdialog.cpp
@@ -79,6 +79,11 @@ ProgressSlideshowDialog::~ProgressSlideshowDialog()
     delete ui;
 }
 
+void ProgressSlideshowDialog::reject()
+{
+    /* prevent closing. */
+}
+
 void ProgressSlideshowDialog::setLabelText(const QString &text)
 {
     QString txt = text;

--- a/recovery/progressslideshowdialog.h
+++ b/recovery/progressslideshowdialog.h
@@ -36,6 +36,7 @@ public slots:
     void pauseIOaccounting();
     void resumeIOaccounting();
     void changeDrive(const QString &drive);
+    void reject();
 
 protected:
     QString _drive;


### PR DESCRIPTION
Pressing the Escape key when installing OSes causes the progress dialog to close. It looks like the operation has been cancelled, but in reality, the image write thread is still running in the background and continuing to install the OS(es).
I tried some things to pop up a cancel dialog to close down the write thread if required, but it ended up being a bit messy, so this a simpler way - Just prevent the Escape key from closing the dialog box in the first place!
