### PR TITLE
Bump libatomic_ops to 7.6.12

### DIFF
--- a/buildroot/package/libatomic_ops/libatomic_ops.mk
+++ b/buildroot/package/libatomic_ops/libatomic_ops.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBATOMIC_OPS_VERSION = libatomic_ops-7_4_0
+LIBATOMIC_OPS_VERSION = v7.6.12
 LIBATOMIC_OPS_SITE = $(call github,ivmai,libatomic_ops,$(LIBATOMIC_OPS_VERSION))
 LIBATOMIC_OPS_AUTORECONF = YES
 


### PR DESCRIPTION
Contains, in particular:
* fix in asm code for x86
* use gcc intrinsic instead of asm code where possible
* eliminate compiler warnings
* support of asan/msan/tsan